### PR TITLE
Integration tests

### DIFF
--- a/features/apis/facebook_api.feature
+++ b/features/apis/facebook_api.feature
@@ -1,0 +1,10 @@
+Feature: Facebook API
+
+  Scenario: Lookup User by ID
+
+  Scenario: User's Facebook Profile
+
+  Scenario: User's Facebook Friends
+
+  Scenario: User's Check-in Data
+

--- a/features/apis/twitter_api.feature
+++ b/features/apis/twitter_api.feature
@@ -1,0 +1,5 @@
+Feature: Twitter API
+
+  Scenario: Lookup User
+
+  Scenario: User's Twitter Stream

--- a/features/registration/twitter_signup.feature
+++ b/features/registration/twitter_signup.feature
@@ -1,0 +1,1 @@
+Feature: Twitter Signup

--- a/features/support/omniauth.rb
+++ b/features/support/omniauth.rb
@@ -1,4 +1,4 @@
-Before '@omniauth' do
+Before do
   OmniAuth.config.test_mode = true
 
   # the symbol passed to mock_auth is the same as the name of the provider set up in the initializer
@@ -26,6 +26,6 @@ Before '@omniauth' do
   })
 end
 
-After '@omniauth' do
+After do
   OmniAuth.config.test_mode = false
 end


### PR DESCRIPTION
move omniauth stubs to run on all tests by default; add twitter and facebook api wrapper features with pending specs. This should fix issue #2 when completed.

Note that we need to add cucumber features to Travis CI's runlist for the project.
